### PR TITLE
adds requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.25.0
+pandas==1.5.3
+patsy==0.5.3
+polars==0.18.4
+pytest==7.4.0
+rpy2==3.5.12
+scipy==1.10.1
+statsmodels==0.13.5


### PR DESCRIPTION
These seem to be the minimal requirements necessary to run tests so far.  Should be good to have them in a `requirements.txt` file so people can `pip install -r requirements.txt` and start.