### PR TITLE
predictions() newdata argument update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,1 +1,15 @@
-# Experimental version
+
+# Development version
+
+Misc:
+
+* Better step size selection for the numerical derivatives used to compute delta method standard errors.
+
+Bugs:
+
+* When newdata was an unseen dataframe, out.columns would be referenced in sanity.py prior to assignment. Thanks to @Vinnie-Palazeti for PR #25.
+
+
+# 0.0.1
+
+Initial release

--- a/marginaleffects/sanity.py
+++ b/marginaleffects/sanity.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 import numpy as np
 import polars as pl
+import pandas as pd
 
 from .datagrid import datagrid
 from .estimands import estimands
@@ -45,6 +46,12 @@ def sanitize_newdata(model, newdata, wts):
 
     elif isinstance(newdata, str) and newdata == "median":
         out = datagrid(newdata=modeldata, FUN_numeric=lambda x: x.median())
+
+    elif isinstance(newdata, pd.DataFrame):
+        out = pl.from_pandas(newdata)
+        
+    else:
+        raise ValueError("No values for newdata.")
 
     if "rowid" in out.columns:
         raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "marginaleffects"
-version = "0.0.1.9001"
+version = "0.0.1.9002"
 description = ""
 authors = ["Vincent Arel-Bundock <vincent.arel-bundock@umontreal.ca>"]
 readme = "README.md"

--- a/tests/test_bugfix.py
+++ b/tests/test_bugfix.py
@@ -1,0 +1,14 @@
+import numpy as np
+import polars as pl
+import pandas as pd
+from marginaleffects import predictions
+import statsmodels.formula.api as smf
+
+
+def test_issue_25():
+    d = pd.DataFrame(np.random.randint(0,100,size=(100, 4)), columns=list('ABCD'))
+    train = d.head(50)
+    test = d.tail(50)
+    m = smf.ols('A ~ B + C + D', data=train).fit()
+    p = predictions(m, newdata=test)
+    assert isinstance(p, pl.DataFrame)


### PR DESCRIPTION
when newdata was an unseen dataframe, out.columns would be referenced in sanity.py prior to assignment.

reproducible example:

```
import numpy as np
import pandas as pd
from marginaleffects import *
import statsmodels.formula.api as smf

d = pd.DataFrame(np.random.randint(0,100,size=(100, 4)), columns=list('ABCD'))

train = d.head(50)
test = d.tail(50)

m = smf.ols('A ~ B + C + D', data=train).fit()
predictions(m, newdata=test)
```