### PR TITLE
minor changes to datagridcf

### DIFF
--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -19,4 +19,8 @@ def test_simple_grid():
 def test_cf():
     assert datagrid(newdata = mtcars, mpg = 32).shape[0] == 1
     assert datagridcf(newdata = mtcars, mpg = [30, 32]).shape[0] == 64
+    assert datagridcf(newdata = mtcars, mpg = 32, am = 0, hp = 100).shape[0] == 32
+    assert datagridcf(newdata = mtcars, am = [0, 1], hp = [100, 110, 120]).shape[0] == 192
     assert datagridcf(newdata = mtcars, mpg = [30, 32]).unique("rowidcf").shape[0] == 32
+    assert set(datagridcf(newdata = mtcars, mpg = [30, 32]).columns) \
+        == {'gear', 'qsec', 'mpg', 'cyl', 'am', 'wt', 'vs', 'drat', 'rowidcf', 'disp', 'rownames', 'hp', 'carb'}


### PR DESCRIPTION
Two minor changes in `datagridcf()`

**1. Drop old values of parameters overwritten their new counterfactual values**

The column name of new counterfactual values of the altered parameters were suffixed with `_right`. When `datagridcf()` is used to generate `newdata`, this is conflicting with `predictions()` (eg), probably because this function is getting the parameter's names from `model`.

This behavior is changed by this code
```
# Drop would-be duplicates
newdata = newdata.drop(df_cross.columns)
```

R :
```
dg <- datagridcf(newdata=mtcars, am = 0:1, hp = c(100, 110, 120))
colnames(dg)
```
output :
```
 [1] "rowidcf" "names"   "mpg"     "cyl"     "disp"    "drat"    "wt"     
[8] "qsec"    "vs"      "gear"    "carb"    "am"      "hp"
```

Python :
```
dg = datagridcf(newdata=dat, am = [0, 1], hp = [100, 110, 120])
print(dg.columns)
```

output (previously) :
`['rownames', 'mpg', 'cyl', 'disp', 'hp', 'drat', 'wt', 'qsec', 'vs', 'am', 'gear', 'carb', 'rowid', 'am_right', 'hp_right', 'rowidcf']`

output (new) :
`['rownames', 'mpg', 'cyl', 'disp', 'drat', 'wt', 'qsec', 'vs', 'gear', 'carb', 'rowid', 'am', 'hp', 'rowidcf']`

Please tell me if (and how?) pytesting this would be a good idea.


**2. Improvement to PR#46 : remove `rowid`**

Python outputs `rowid` along `rowidcf` while R outputs only `rowidcf`. Moreover, Python's `rowid` is identical to `rowidcf`. Simply renaming this column seems the most effective way to resolve this.

output (cumulative) :
`['rownames', 'mpg', 'cyl', 'disp', 'drat', 'wt', 'qsec', 'vs', 'gear', 'carb', 'rowidcf', 'am', 'hp']`