### PR TITLE
Check input columns are not reserved names

### DIFF
--- a/marginaleffects/predictions.py
+++ b/marginaleffects/predictions.py
@@ -68,7 +68,7 @@ def predictions(
         - type: prediction type, as defined by the `type` argument
         - group: (optional) value of the grouped outcome (e.g., categorical outcome models)
         - estimate: predicted outcome
-        - std.error: standard errors computed using the delta method.
+        - std_error: standard errors computed using the delta method.
         - p_value: p value associated with the `estimate` column.
         - s_value: Shannon information transforms of p values.
         - conf_low: lower bound of the confidence interval (or equal-tailed interval for Bayesian models)

--- a/marginaleffects/sanity.py
+++ b/marginaleffects/sanity.py
@@ -54,15 +54,15 @@ def sanitize_newdata(model, newdata, wts, by=[]):
         except ImportError:
             out = newdata
 
-    # reserved_names = {
-    #     "rowid", "type",
-    #     "group", "estimate",
-    #     "std_error", "p_value",
-    #     "s_value", "conf_low",
-    #     "conf_high", "term",
-    #     "contrast", "statistic"}
-    # assert not (set(out.columns) & reserved_names), \
-    #     f"Input data contain reserved column name(s) : {set(out.columns).intersection(reserved_names)}"
+    reserved_names = {
+        "rowid", "type",
+        "group", "estimate",
+        "std_error", "p_value",
+        "s_value", "conf_low",
+        "conf_high", "term",
+        "contrast", "statistic"}
+    assert not (set(out.columns) & reserved_names), \
+        f"Input data contain reserved column name(s) : {set(out.columns).intersection(reserved_names)}"
 
     datagrid_explicit = None
     if isinstance(out, pl.DataFrame) and hasattr(out, "datagrid_explicit"):

--- a/marginaleffects/sanity.py
+++ b/marginaleffects/sanity.py
@@ -55,14 +55,22 @@ def sanitize_newdata(model, newdata, wts, by=[]):
             out = newdata
 
     reserved_names = {
-        "rowid", "type",
-        "group", "estimate",
-        "std_error", "p_value",
-        "s_value", "conf_low",
-        "conf_high", "term",
-        "contrast", "statistic"}
-    assert not (set(out.columns) & reserved_names), \
-        f"Input data contain reserved column name(s) : {set(out.columns).intersection(reserved_names)}"
+        "rowid",
+        "type",
+        "group",
+        "estimate",
+        "std_error",
+        "p_value",
+        "s_value",
+        "conf_low",
+        "conf_high",
+        "term",
+        "contrast",
+        "statistic",
+    }
+    assert not (
+        set(out.columns) & reserved_names
+    ), f"Input data contain reserved column name(s) : {set(out.columns).intersection(reserved_names)}"
 
     datagrid_explicit = None
     if isinstance(out, pl.DataFrame) and hasattr(out, "datagrid_explicit"):

--- a/marginaleffects/sanity.py
+++ b/marginaleffects/sanity.py
@@ -54,6 +54,16 @@ def sanitize_newdata(model, newdata, wts, by=[]):
         except ImportError:
             out = newdata
 
+    # reserved_names = {
+    #     "rowid", "type",
+    #     "group", "estimate",
+    #     "std_error", "p_value",
+    #     "s_value", "conf_low",
+    #     "conf_high", "term",
+    #     "contrast", "statistic"}
+    # assert not (set(out.columns) & reserved_names), \
+    #     f"Input data contain reserved column name(s) : {set(out.columns).intersection(reserved_names)}"
+
     datagrid_explicit = None
     if isinstance(out, pl.DataFrame) and hasattr(out, "datagrid_explicit"):
         datagrid_explicit = out.datagrid_explicit


### PR DESCRIPTION
Hi @vincentarelbundock , this should fix #90 
I added all columns that might be returned by all three main functions in the `reserved_names` set. However, I am afraid this will block unproblematic situations, eg when it turns out that the problematic column is not used by pymarginaleffects. I don't see a simple way to filter these columns out of the check.

Thank you