### PR TITLE
Get variables from formula

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,8 @@ readme: ## render Quarto readme
 	mv -f docs/get_started.md README.md
 
 lint: ## run the lint checkers
-	poetry run isort marginaleffects --check
-	poetry run black marginaleffects --check
-	poetry run flake8 marginaleffects
+	poetry run ruff format marginaleffects
+	poetry run ruff format tests
 
 install: ## install in poetry venv
 	poetry install

--- a/marginaleffects/model_statsmodels.py
+++ b/marginaleffects/model_statsmodels.py
@@ -52,7 +52,13 @@ class ModelStatsmodels(ModelAbstract):
         if variables is None:
             formula = self.formula
             columns = self.modeldata.columns
-            variables = list({var for var in columns if re.search(rf"\b{re.escape(var)}\b", formula.split('~')[1])})
+            variables = list(
+                {
+                    var
+                    for var in columns
+                    if re.search(rf"\b{re.escape(var)}\b", formula.split("~")[1])
+                }
+            )
 
         if isinstance(variables, (str, dict)):
             variables = [variables] if isinstance(variables, str) else variables

--- a/marginaleffects/model_statsmodels.py
+++ b/marginaleffects/model_statsmodels.py
@@ -50,10 +50,9 @@ class ModelStatsmodels(ModelAbstract):
 
     def get_variables_names(self, variables=None, newdata=None):
         if variables is None:
-            variables = self.model.model.exog_names
-            variables = [re.sub("\[.*\]", "", x) for x in variables]
-            variables = [x for x in variables if x in self.modeldata.columns]
-            variables = pl.Series(variables).unique().to_list()
+            formula = self.formula
+            columns = self.modeldata.columns
+            variables = list({var for var in columns if re.search(rf"\b{re.escape(var)}\b", formula.split('~')[1])})
 
         if isinstance(variables, (str, dict)):
             variables = [variables] if isinstance(variables, str) else variables

--- a/tests/test_analytic.py
+++ b/tests/test_analytic.py
@@ -30,28 +30,25 @@ def test_linear_quadratic():
     assert_series_equal(res["estimate"], res["truth"], check_names=False, atol=0.01)
 
 
-# Fails at `res = slopes(mod, newdata = nd)`
-# with ValueError: There is no valid column name in `variables`.
-
-# def test_linear_log():
-# 	np.random.seed(1)
-# 	f = "y ~ np.log(x)"
-# 	def truth(x):
-# 		return(1 / x)
-# 	N = 10000
-# 	dat = pl.DataFrame({'x' : np.random.uniform(size=N)})
-# 	dat = dat.with_columns(
-# 		y = np.log(pl.col('x')) + np.random.normal(size=N)
-# 	)
-# 	mod = smf.ols(f, dat.to_pandas()).fit()
-# 	nd = datagrid(newdata = dat, x = range(1, 5))
-# 	res = slopes(mod, newdata = nd)
-# 	res = res.with_columns(
-# 		truth = truth(pl.col('x')).cast(pl.Float64)
-# 	)
-# 	assert_series_equal(
-# 		res['estimate'], res['truth'], check_names=False, atol=0.01
-# 	)
+def test_linear_log():
+	np.random.seed(1)
+	f = "y ~ np.log(x)"
+	def truth(x):
+		return(1 / x)
+	N = 10000
+	dat = pl.DataFrame({'x' : np.random.uniform(size=N)})
+	dat = dat.with_columns(
+		y = np.log(pl.col('x')) + np.random.normal(size=N)
+	)
+	mod = smf.ols(f, dat.to_pandas()).fit()
+	nd = datagrid(newdata = dat, x = range(1, 5))
+	res = slopes(mod, newdata = nd)
+	res = res.with_columns(
+		truth = truth(pl.col('x')).cast(pl.Float64)
+	)
+	assert_series_equal(
+		res['estimate'], res['truth'], check_names=False, atol=0.02
+	)
 
 
 def test_logit():

--- a/tests/test_analytic.py
+++ b/tests/test_analytic.py
@@ -31,24 +31,20 @@ def test_linear_quadratic():
 
 
 def test_linear_log():
-	np.random.seed(1)
-	f = "y ~ np.log(x)"
-	def truth(x):
-		return(1 / x)
-	N = 10000
-	dat = pl.DataFrame({'x' : np.random.uniform(size=N)})
-	dat = dat.with_columns(
-		y = np.log(pl.col('x')) + np.random.normal(size=N)
-	)
-	mod = smf.ols(f, dat.to_pandas()).fit()
-	nd = datagrid(newdata = dat, x = range(1, 5))
-	res = slopes(mod, newdata = nd)
-	res = res.with_columns(
-		truth = truth(pl.col('x')).cast(pl.Float64)
-	)
-	assert_series_equal(
-		res['estimate'], res['truth'], check_names=False, atol=0.02
-	)
+    np.random.seed(1)
+    f = "y ~ np.log(x)"
+
+    def truth(x):
+        return 1 / x
+
+    N = 10000
+    dat = pl.DataFrame({"x": np.random.uniform(size=N)})
+    dat = dat.with_columns(y=np.log(pl.col("x")) + np.random.normal(size=N))
+    mod = smf.ols(f, dat.to_pandas()).fit()
+    nd = datagrid(newdata=dat, x=range(1, 5))
+    res = slopes(mod, newdata=nd)
+    res = res.with_columns(truth=truth(pl.col("x")).cast(pl.Float64))
+    assert_series_equal(res["estimate"], res["truth"], check_names=False, atol=0.02)
 
 
 def test_logit():


### PR DESCRIPTION
This fixes #91 with the solution by @RoelVerbelen. I added `.split('~')[1]` to the formula before regexing because we don't want the left hand side of it.
It fixes [this problem](https://github.com/vincentarelbundock/pymarginaleffects/pull/87#issuecomment-1947382926) in test_analytic.