### PR TITLE
Fix datagrid's grid_type parameter check

### DIFF
--- a/marginaleffects/datagrid.py
+++ b/marginaleffects/datagrid.py
@@ -71,7 +71,7 @@ def datagrid(
     msg = "grid_type must be 'mean_or_mode', 'balanced', or 'counterfactual'"
     assert isinstance(grid_type, str) and grid_type in [
         "mean_or_mode",
-        "explicit",
+        "balanced",
         "counterfactual",
     ], msg
 


### PR DESCRIPTION
The assert is checking for ["mean_or_mode",  "explicit", and "counterfactual"] when `explicit` is not a valid parameter, `balanced` is. This means that the `balanced` code path is currently not usable (calls to datagrid with `grid_type="balanced"` will fail). 