### PR TITLE
Improved parsing of contrast encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 New:
 
 * `datagrid()` gets new arguments: by, response, FUN_categorical, FUN_binary, FUN_numeric, FUN_other
+* Improved parsing of categorical variables from formulas. Thanks to @danielkberry for Pull Request #225.
 
 # 0.1.3
 

--- a/marginaleffects/formulaic_utils.py
+++ b/marginaleffects/formulaic_utils.py
@@ -8,7 +8,7 @@ __all__ = ["listwise_deletion", "model_matrices"]
 
 
 def parse_variables_categorical(fml: str) -> list[str]:
-    return re.findall(r"C\((.*?)\)", fml)
+    return re.findall(r"C\(\s*([^,)\s]+)", fml)
 
 
 # @validate_types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marginaleffects"
-version = "0.1.3.1"
+version = "0.1.3.2"
 license = "GPL-3.0-or-later"
 description = "Predictions, counterfactual comparisons, slopes, and hypothesis tests for statistical models."
 readme = "README.md"

--- a/tests/test_formulaic_utils.py
+++ b/tests/test_formulaic_utils.py
@@ -1,0 +1,19 @@
+import pytest
+from marginaleffects.formulaic_utils import parse_variables_categorical
+
+@pytest.mark.parametrize(
+    "formula,expected",
+    [
+        ("y ~ C(x1) + x2", ["x1"]),
+        ("y ~ C(x1) + C(x2)", ["x1", "x2"]),
+        ("y ~ x1 + x2", []),
+        ("y ~ C(x1, levels=[1,2]) + C(x2)", ["x1", "x2"]),
+        ("y ~ C(x1) + C(x2) + C(x3)", ["x1", "x2", "x3"]),
+        ("y ~ x1 + C(x2) + x3", ["x2"]),
+        ("y ~ C(x1) * C(x2)", ["x1", "x2"]),
+        ("y ~ C(x1) + C(x2) + x3 + C(x4)", ["x1", "x2", "x4"]),
+        ("y ~ C(x1) + x2 + C(x3, Treatment(reference='base-level'))", ["x1", "x3"]),
+    ]
+)
+def test_parse_variables_categorical(formula, expected):
+    assert parse_variables_categorical(formula) == expected


### PR DESCRIPTION
This adds support to parse categorical variables encoded with transforms like `Treatment`. Previously, when parsing a term like `C(branch, Treatment(reference='control'))` the function would output `branch, Treatment(reference='control')` instead of the expected `branch`. 